### PR TITLE
Improve windows error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ let platform_utils;
 const noopPlatformUtils = {
   getRunningInputAudioProcesses: () => {
     return ['', ''];
+  },
+  getProcessesAccessingMicrophoneWithResult: () => {
+    return {
+      success: true,
+      error: null,
+      processes: ['', '']
+    };
   }
 };
 
@@ -18,6 +25,7 @@ if (process.platform === 'darwin') {
 module.exports = {
   // Common exports that work on all platforms
   getRunningInputAudioProcesses: platform_utils.getRunningInputAudioProcesses,
+  getProcessesAccessingMicrophoneWithResult: platform_utils.getProcessesAccessingMicrophoneWithResult,
   INFO_ERROR_CODE: 1,
   ERROR_DOMAIN: "com.MicrophoneUsageMonitor",
   

--- a/macOS/AudioProcessMonitor.h
+++ b/macOS/AudioProcessMonitor.h
@@ -14,8 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSString *> *runningBundleIDs;
 
 - (instancetype)init;
-+ (struct AudioProcessResult)getRunningInputAudioProcesses;
++ (NSArray<NSString *> *)getRunningInputAudioProcesses:(NSError **)error;
++ (struct AudioProcessResult)getProcessesAccessingMicrophoneWithResult;
 
 @end
 
-NS_ASSUME_NONNULL_END 
+NS_ASSUME_NONNULL_END

--- a/macOS/AudioProcessMonitor.h
+++ b/macOS/AudioProcessMonitor.h
@@ -1,6 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 
+struct AudioProcessResult {
+    NSArray<NSString*>* _Nullable processes;
+    NSError* _Nullable error;
+    bool success;
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AudioProcessMonitor : NSObject
@@ -8,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSString *> *runningBundleIDs;
 
 - (instancetype)init;
-+ (NSArray<NSString *> *)getRunningInputAudioProcesses:(NSError **)error;
++ (struct AudioProcessResult)getRunningInputAudioProcesses;
 
 @end
 

--- a/macOS/AudioProcessMonitor.m
+++ b/macOS/AudioProcessMonitor.m
@@ -12,7 +12,104 @@
   return self;
 }
 
-+ (struct AudioProcessResult)getRunningInputAudioProcesses {
++ (NSArray<NSString *> *)getRunningInputAudioProcesses:(NSError **)error {
+  AudioObjectPropertyAddress address = {
+      kAudioHardwarePropertyProcessObjectList,
+      kAudioObjectPropertyScopeGlobal,
+      kAudioObjectPropertyElementMain
+  };
+
+  UInt32 dataSize = 0;
+  OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
+                                                 &address,
+                                                 0,
+                                                 NULL,
+                                                 &dataSize);
+
+  if (status != noErr) {
+      if (error) {
+          *error = [NSError errorWithDomain:@"AudioProcessMonitor"
+                                     code:status
+                                 userInfo:@{NSLocalizedDescriptionKey: @"Failed to get process list size"}];
+      }
+      return @[];
+  }
+
+  NSInteger count = dataSize / sizeof(AudioObjectID);
+  AudioObjectID *processIDs = malloc(dataSize);
+
+  if (!processIDs) {
+    if (error) {
+        *error = [NSError errorWithDomain:@"AudioProcessMonitor"
+                                   code:-1
+                               userInfo:@{NSLocalizedDescriptionKey: @"Failed to allocate memory"}];
+    }
+    return @[];
+  }
+
+  status = AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                    &address,
+                                    0,
+                                    NULL,
+                                    &dataSize,
+                                    processIDs);
+
+  if (status != noErr) {
+    free(processIDs);
+    if (error) {
+        *error = [NSError errorWithDomain:@"AudioProcessMonitor"
+                                   code:status
+                               userInfo:@{NSLocalizedDescriptionKey: @"Failed to get process list"}];
+    }
+    return @[];
+  }
+
+  NSMutableArray<NSString *> *activeBundleIDs = [NSMutableArray array];
+
+  for (NSInteger i = 0; i < count; i++) {
+    AudioObjectID processID = processIDs[i];
+
+    // Check if process is running
+    address.mSelector = kAudioProcessPropertyIsRunningInput;
+    UInt32 isRunning = 0;
+    dataSize = sizeof(isRunning);
+
+    status = AudioObjectGetPropertyData(processID,
+                                      &address,
+                                      0,
+                                      NULL,
+                                      &dataSize,
+                                      &isRunning);
+
+    if (status != noErr || !isRunning) {
+        continue;
+    }
+
+    // Get bundle ID
+    address.mSelector = kAudioProcessPropertyBundleID;
+    CFStringRef bundleIDRef = NULL;
+    dataSize = sizeof(bundleIDRef);
+
+    status = AudioObjectGetPropertyData(processID,
+                                      &address,
+                                      0,
+                                      NULL,
+                                      &dataSize,
+                                      &bundleIDRef);
+
+    if (status == noErr && bundleIDRef) {
+        NSString *bundleID = (NSString *)CFBridgingRelease(bundleIDRef);
+        if (bundleID.length > 0) {
+            [activeBundleIDs addObject:bundleID];
+        }
+    }
+  }
+
+  free(processIDs);
+  return [activeBundleIDs copy];
+}
+
++ (struct AudioProcessResult)getProcessesAccessingMicrophoneWithResult {
   struct AudioProcessResult result = {nil, nil, true};
   
   AudioObjectPropertyAddress address = {
@@ -113,4 +210,4 @@
   return result;
 }
 
-@end 
+@end

--- a/macOS/AudioProcessMonitor.m
+++ b/macOS/AudioProcessMonitor.m
@@ -111,7 +111,7 @@
 
 + (struct AudioProcessResult)getProcessesAccessingMicrophoneWithResult {
   struct AudioProcessResult result = {nil, nil, true};
-  
+
   AudioObjectPropertyAddress address = {
       kAudioHardwarePropertyProcessObjectList,
       kAudioObjectPropertyScopeGlobal,

--- a/macOS/mac_utils.mm
+++ b/macOS/mac_utils.mm
@@ -22,10 +22,10 @@ void MakeKeyAndOrderFront(const Napi::CallbackInfo &info) {
 // Gets a list of processes that are accessing input (microphone) - original interface
 Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  
+
   NSError *error = nil;
   NSArray<NSString *> *processes = [AudioProcessMonitor getRunningInputAudioProcesses:&error];
-  
+
   Napi::Array result = Napi::Array::New(env);
   for (NSUInteger i = 0; i < [processes count]; i++) {
     NSString *process = [processes objectAtIndex:i];

--- a/macOS/mac_utils.mm
+++ b/macOS/mac_utils.mm
@@ -19,15 +19,30 @@ void MakeKeyAndOrderFront(const Napi::CallbackInfo &info) {
   [[contentView window] makeKeyAndOrderFront:nil];
 }
 
-// Gets a list of processes that are accessing input (microphone)
+// Gets a list of processes that are accessing input (microphone) - original interface
 Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   
-  struct AudioProcessResult result = [AudioProcessMonitor getRunningInputAudioProcesses];
+  NSError *error = nil;
+  NSArray<NSString *> *processes = [AudioProcessMonitor getRunningInputAudioProcesses:&error];
   
+  Napi::Array result = Napi::Array::New(env);
+  for (NSUInteger i = 0; i < [processes count]; i++) {
+    NSString *process = [processes objectAtIndex:i];
+    result.Set(i, Napi::String::New(env, [process UTF8String]));
+  }
+
+  return result;
+}
+
+// Gets processes accessing microphone with structured result
+Napi::Value GetProcessesAccessingMicrophoneWithResult(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  struct AudioProcessResult result = [AudioProcessMonitor getProcessesAccessingMicrophoneWithResult];
+
   // Create a JavaScript object to represent the AudioProcessResult
   Napi::Object resultObj = Napi::Object::New(env);
-  
   if (!result.success) {
     // Set error information
     resultObj.Set("success", Napi::Boolean::New(env, false));
@@ -39,7 +54,7 @@ Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
     // Set success information
     resultObj.Set("success", Napi::Boolean::New(env, true));
     resultObj.Set("error", env.Null());
-    
+
     // Convert processes array
     Napi::Array processesArray = Napi::Array::New(env);
     for (NSUInteger i = 0; i < [result.processes count]; i++) {
@@ -167,6 +182,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
   exports.Set(Napi::String::New(env, "getRunningInputAudioProcesses"),
               Napi::Function::New(env, GetRunningInputAudioProcesses));
+
+  exports.Set(Napi::String::New(env, "getProcessesAccessingMicrophoneWithResult"),
+              Napi::Function::New(env, GetProcessesAccessingMicrophoneWithResult));
 
   exports.Set(Napi::String::New(env, "startMonitoringMic"),
               Napi::Function::New(env, StartMonitoringMic));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "node-mac-utils",
-	"version": "1.1.1",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "node-mac-utils",
-			"version": "1.1.1",
+			"version": "1.2.1",
 			"dependencies": {
 				"bindings": "1.5.0",
 				"node-addon-api": "6.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "node-mac-utils",
-	"version": "1.0.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "node-mac-utils",
-			"version": "1.0.0",
+			"version": "1.1.1",
 			"dependencies": {
 				"bindings": "1.5.0",
 				"node-addon-api": "6.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "node-mac-utils",
-	"version": "1.1.1",
-	"description": "A native Node.js module with utilities for macOS",
+	"version": "1.2.1",
+	"description": "A native Node.js module with utilities for macOS and Windows",
 	"main": "index.js",
 	"type": "index.d.ts",
 	"scripts": {

--- a/test-mic-monitor.js
+++ b/test-mic-monitor.js
@@ -46,21 +46,15 @@ class MicrophoneStatusEmitter extends EventEmitter {
 async function displayMicProcesses() {
   try {
     console.log('\n--- Current Microphone Processes ---');
-    const result = getRunningInputAudioProcesses();
+    const processes = getRunningInputAudioProcesses(); // Returns simple array
 
-    if (result.success) {
-      if (result.processes.length === 0) {
-        console.log('No processes are currently using the microphone');
-      } else {
-        console.log('Processes using the microphone:');
-        result.processes.forEach((process, index) => {
-          console.log(`${index + 1}. ${process}`);
-        });
-      }
+    if (processes.length === 0) {
+      console.log('No processes are currently using the microphone');
     } else {
-      console.error('Error getting microphone processes:', result.error);
-      console.error('Error code:', result.code);
-      console.error('Error domain:', result.domain);
+      console.log('Processes using the microphone:');
+      processes.forEach((process, index) => {
+        console.log(`${index + 1}. ${process}`);
+      });
     }
   } catch (error) {
     console.error('Error getting microphone processes:', error.message);

--- a/test-mic-monitor.js
+++ b/test-mic-monitor.js
@@ -46,18 +46,30 @@ class MicrophoneStatusEmitter extends EventEmitter {
 async function displayMicProcesses() {
   try {
     console.log('\n--- Current Microphone Processes ---');
-    const processes = await getRunningInputAudioProcesses();
+    const result = getRunningInputAudioProcesses();
 
-    if (processes.length === 0) {
-      console.log('No processes are currently using the microphone');
+    if (result.success) {
+      if (result.processes.length === 0) {
+        console.log('No processes are currently using the microphone');
+      } else {
+        console.log('Processes using the microphone:');
+        result.processes.forEach((process, index) => {
+          console.log(`${index + 1}. ${process}`);
+        });
+      }
     } else {
-      console.log('Processes using the microphone:');
-      processes.forEach((process, index) => {
-        console.log(`${index + 1}. ${process}`);
-      });
+      console.error('Error getting microphone processes:', result.error);
+      console.error('Error code:', result.code);
+      console.error('Error domain:', result.domain);
     }
   } catch (error) {
     console.error('Error getting microphone processes:', error.message);
+    if (error.code) {
+      console.error('Error code:', error.code);
+    }
+    if (error.domain) {
+      console.error('Error domain:', error.domain);
+    }
   }
 }
 
@@ -72,6 +84,10 @@ function startMicrophoneStatusEmitter() {
     console.log('⚠️ Microphone Info:', info);
   });
 
+  emitter.on('error', (error) => {
+    console.error('❌ Microphone Error:', error);
+  });
+
   emitter.start();
 }
 
@@ -83,6 +99,12 @@ function startMicMonitor() {
       if (error) {
         console.error('Node - error');
         console.error('Error starting microphone monitor:', error.message);
+        if (error.code) {
+          console.error('Error code:', error.code);
+        }
+        if (error.domain) {
+          console.error('Error domain:', error.domain);
+        }
       } else {
         console.log(`Node: [${timestamp}] Microphone active:`, microphoneActive);
       }
@@ -90,6 +112,12 @@ function startMicMonitor() {
   } catch (error) {
     console.error('Node - error');
     console.error('Error starting microphone monitor:', error.message);
+    if (error.code) {
+      console.error('Error code:', error.code);
+    }
+    if (error.domain) {
+      console.error('Error domain:', error.domain);
+    }
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -8,16 +8,26 @@ async function runTests() {
     try {
         // Test getRunningInputAudioProcesses
         console.log('\nTesting getRunningInputAudioProcesses:');
-        const processes = utils.getRunningInputAudioProcesses();
-        console.log('Audio processes:', processes);
+        const result = utils.getRunningInputAudioProcesses();
+
+        console.log('result', result);
+        if (result.success) {
+            console.log('Audio processes:', result.processes);
+        } else {
+            console.error('Error getting audio processes:', result.error);
+            console.error('Error code:', result.code);
+            console.error('Error domain:', result.domain);
+        }
 
         // Test platform-specific functions
         if (process.platform === 'darwin') {
             console.log('\nTesting Mac-specific functions:');
             console.log('makeKeyAndOrderFront available:', !!utils.makeKeyAndOrderFront);
+            console.log('startMonitoringMic available:', !!utils.startMonitoringMic);
+            console.log('stopMonitoringMic available:', !!utils.stopMonitoringMic);
         } else if (process.platform === 'win32') {
             console.log('\nTesting Windows-specific functions:');
-            // Add any Windows-specific function tests here
+            console.log('getRunningInputAudioProcesses available:', !!utils.getRunningInputAudioProcesses);
         } else {
             console.log('node-mac-utils Unsupported platform:', process.platform);
         }
@@ -27,7 +37,13 @@ async function runTests() {
         console.log(Object.keys(utils));
 
     } catch (error) {
-        console.error('Test failed:', error);
+        console.error('Test failed:', error.message);
+        if (error.code) {
+            console.error('Error code:', error.code);
+        }
+        if (error.domain) {
+            console.error('Error domain:', error.domain);
+        }
         process.exit(1);
     }
 }

--- a/test.js
+++ b/test.js
@@ -4,19 +4,27 @@ const utils = require('./index.js');
 // Test function to run all checks
 async function runTests() {
     console.log('Running on platform:', process.platform);
-    
     try {
-        // Test getRunningInputAudioProcesses
-        console.log('\nTesting getRunningInputAudioProcesses:');
-        const result = utils.getRunningInputAudioProcesses();
+        // Test original getRunningInputAudioProcesses (returns array)
+        console.log('\nTesting getRunningInputAudioProcesses (original):');
+        const processes = utils.getRunningInputAudioProcesses();
+        console.log('Type:', typeof processes);
+        console.log('Is Array:', Array.isArray(processes));
+        console.log('Audio processes:', processes);
 
-        console.log('result', result);
+        // Test new getProcessesAccessingMicrophoneWithResult (returns structured result)
+        console.log('\nTesting getProcessesAccessingMicrophoneWithResult (new):');
+        const result = utils.getProcessesAccessingMicrophoneWithResult();
+        console.log('Type:', typeof result);
+        console.log('Result:', result);
+
         if (result.success) {
-            console.log('Audio processes:', result.processes);
+            console.log('✓ Success - Audio processes:', result.processes);
+            console.log('  Process count:', result.processes.length);
         } else {
-            console.error('Error getting audio processes:', result.error);
-            console.error('Error code:', result.code);
-            console.error('Error domain:', result.domain);
+            console.error('✗ Error getting audio processes:', result.error);
+            console.error('  Error code:', result.code);
+            console.error('  Error domain:', result.domain);
         }
 
         // Test platform-specific functions
@@ -28,8 +36,19 @@ async function runTests() {
         } else if (process.platform === 'win32') {
             console.log('\nTesting Windows-specific functions:');
             console.log('getRunningInputAudioProcesses available:', !!utils.getRunningInputAudioProcesses);
+            console.log('getProcessesAccessingMicrophoneWithResult available:', !!utils.getProcessesAccessingMicrophoneWithResult);
         } else {
             console.log('node-mac-utils Unsupported platform:', process.platform);
+        }
+
+        // Compare both methods
+        console.log('\nComparing both methods:');
+        console.log('Original method returns:', Array.isArray(processes) ? 'Array' : typeof processes);
+        console.log('New method returns:', typeof result === 'object' && result.hasOwnProperty('success') ? 'Structured Object' : typeof result);
+
+        if (result.success && Array.isArray(processes)) {
+            console.log('Process count - Original:', processes.length, 'New:', result.processes.length);
+            console.log('Data matches:', JSON.stringify(processes) === JSON.stringify(result.processes));
         }
 
         // Log all available exports
@@ -49,4 +68,4 @@ async function runTests() {
 }
 
 // Run the tests
-runTests(); 
+runTests();

--- a/windows/AudioProcessMonitor.cpp
+++ b/windows/AudioProcessMonitor.cpp
@@ -40,7 +40,8 @@ static std::string GetProcessExecutablePath(DWORD processID) {
     return "Unknown";
 }
 
-AudioProcessResult GetAudioInputProcesses() {
+// New function with structured result
+AudioProcessResult GetProcessesAccessingMicrophoneWithResult() {
     AudioProcessResult result;
     std::unordered_set<std::string> seen;  // Track unique strings
     HRESULT hr = CoInitialize(nullptr);
@@ -171,4 +172,10 @@ AudioProcessResult GetAudioInputProcesses() {
     CoUninitialize();
 
     return result;
+}
+
+// Original function returning vector (restored for backward compatibility)
+std::vector<std::string> GetAudioInputProcesses() {
+    AudioProcessResult result = GetProcessesAccessingMicrophoneWithResult();
+    return result.processes;
 }

--- a/windows/AudioProcessMonitor.cpp
+++ b/windows/AudioProcessMonitor.cpp
@@ -174,8 +174,108 @@ AudioProcessResult GetProcessesAccessingMicrophoneWithResult() {
     return result;
 }
 
-// Original function returning vector (restored for backward compatibility)
 std::vector<std::string> GetAudioInputProcesses() {
-    AudioProcessResult result = GetProcessesAccessingMicrophoneWithResult();
-    return result.processes;
+    std::vector<std::string> results;
+    std::unordered_set<std::string> seen;  // Track unique strings
+    HRESULT hr = CoInitialize(nullptr);
+
+    if (FAILED(hr)) {
+        return results;
+    }
+
+    IMMDeviceEnumerator* pEnumerator = nullptr;
+    IMMDevice* pDevice = nullptr;
+    IAudioSessionManager2* pSessionManager = nullptr;
+    IAudioSessionEnumerator* pSessionEnum = nullptr;
+
+    hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pEnumerator);
+    if (FAILED(hr)) {
+        return results;
+    }
+
+    // Get default capture (microphone) device
+    hr = pEnumerator->GetDefaultAudioEndpoint(eCapture, eMultimedia, &pDevice);
+    if (FAILED(hr)) {
+        pEnumerator->Release();
+        return results;
+    }
+
+    bool isActive = false;
+    IAudioMeterInformation* pMeter = nullptr;
+
+    // Get the Audio Meter Interface
+    hr = pDevice->Activate(__uuidof(IAudioMeterInformation), CLSCTX_ALL, nullptr, (void**)&pMeter);
+    if (SUCCEEDED(hr)) {
+        float peakValue = 0.0f;
+        pMeter->GetPeakValue(&peakValue);
+        isActive = (peakValue > 0.0f);
+        pMeter->Release();
+    }
+
+    if (!isActive) {
+        pDevice->Release();
+        pEnumerator->Release();
+        CoUninitialize();
+        return results;
+    }
+
+    // Get session manager
+    hr = pDevice->Activate(__uuidof(IAudioSessionManager2), CLSCTX_ALL, nullptr, (void**)&pSessionManager);
+    if (FAILED(hr)) {
+        std::cerr << "Failed to activate IAudioSessionManager2. HRESULT: " << std::hex << hr << std::endl;
+        pDevice->Release();
+        pEnumerator->Release();
+        CoUninitialize();
+        return results;
+    }
+
+    // Get audio session enumerator
+    hr = pSessionManager->GetSessionEnumerator(&pSessionEnum);
+    if (FAILED(hr)) {
+        std::cerr << "Failed to get IAudioSessionEnumerator. HRESULT: " << std::hex << hr << std::endl;
+        pSessionManager->Release();
+        pDevice->Release();
+        pEnumerator->Release();
+        CoUninitialize();
+        return results;
+    }
+
+    int sessionCount = 0;
+    pSessionEnum->GetCount(&sessionCount);
+
+    for (int i = 0; i < sessionCount; i++) {
+        IAudioSessionControl* pSessionControl = nullptr;
+        hr = pSessionEnum->GetSession(i, &pSessionControl);
+        if (FAILED(hr)) continue;
+
+        IAudioSessionControl2* pSessionControl2 = nullptr;
+        hr = pSessionControl->QueryInterface(__uuidof(IAudioSessionControl2), (void**)&pSessionControl2);
+        if (SUCCEEDED(hr)) {
+            DWORD processID = 0;
+            pSessionControl2->GetProcessId(&processID);
+
+            AudioSessionState state;
+            pSessionControl2->GetState(&state);
+
+            if (processID != 0 && state == AudioSessionStateActive) {
+                std::string processPath = GetProcessExecutablePath(processID);
+
+                // Only insert if not already seen
+                if (seen.insert(processPath).second) {
+                    results.push_back(processPath);
+                }
+            }
+            pSessionControl2->Release();
+        }
+        pSessionControl->Release();
+    }
+
+    // Cleanup
+    pSessionEnum->Release();
+    pSessionManager->Release();
+    pDevice->Release();
+    pEnumerator->Release();
+    CoUninitialize();
+
+    return results;
 }

--- a/windows/AudioProcessMonitor.h
+++ b/windows/AudioProcessMonitor.h
@@ -2,4 +2,13 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> GetAudioInputProcesses(); 
+struct AudioProcessResult {
+    std::vector<std::string> processes;
+    HRESULT errorCode;
+    std::string errorMessage;
+    bool success;
+
+    AudioProcessResult() : errorCode(S_OK), success(true) {}
+};
+
+AudioProcessResult GetAudioInputProcesses();

--- a/windows/AudioProcessMonitor.h
+++ b/windows/AudioProcessMonitor.h
@@ -11,4 +11,8 @@ struct AudioProcessResult {
     AudioProcessResult() : errorCode(S_OK), success(true) {}
 };
 
-AudioProcessResult GetAudioInputProcesses();
+// Original function returning vector (restored)
+std::vector<std::string> GetAudioInputProcesses();
+
+// New function with structured result
+AudioProcessResult GetProcessesAccessingMicrophoneWithResult();

--- a/windows/win_utils.cpp
+++ b/windows/win_utils.cpp
@@ -59,10 +59,13 @@ Napi::Value GetProcessesAccessingMicrophoneWithResult(const Napi::CallbackInfo& 
 
 // Initialize the module exports
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-  exports.Set(Napi::String::New(env, "getRunningInputAudioProcesses"),
-              Napi::Function::New(env, &GetRunningInputAudioProcesses));
-  exports.Set(Napi::String::New(env, "getProcessesAccessingMicrophoneWithResult"),
-              Napi::Function::New(env, &GetProcessesAccessingMicrophoneWithResult));
+  Napi::Value (*originalAudioProcessesFunc)(const Napi::CallbackInfo&) = GetRunningInputAudioProcesses;
+  Napi::Value (*microphoneAccessFunc)(const Napi::CallbackInfo&) = GetProcessesAccessingMicrophoneWithResult;
+  
+  exports.Set("getRunningInputAudioProcesses",
+              Napi::Function::New(env, originalAudioProcessesFunc));
+  exports.Set("getProcessesAccessingMicrophoneWithResult",
+              Napi::Function::New(env, microphoneAccessFunc));
 
   return exports;
 }

--- a/windows/win_utils.cpp
+++ b/windows/win_utils.cpp
@@ -2,36 +2,19 @@
 #include <windows.h>
 #include "AudioProcessMonitor.h"
 
-// Gets a list of processes that are accessing input (microphone)
+// Gets a list of processes that are accessing input (microphone) - original interface
 Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
   try {
-    AudioProcessResult result = GetAudioInputProcesses();
+    std::vector<std::string> processes = GetAudioInputProcesses();
 
-    // Create a JavaScript object to represent the AudioProcessResult
-    Napi::Object resultObj = Napi::Object::New(env);
-    if (!result.success) {
-      // Set error information
-      resultObj.Set("success", Napi::Boolean::New(env, false));
-      resultObj.Set("error", Napi::String::New(env, result.errorMessage));
-      resultObj.Set("code", Napi::Number::New(env, result.errorCode));
-      resultObj.Set("domain", Napi::String::New(env, "AudioProcessMonitor"));
-      resultObj.Set("processes", Napi::Array::New(env));
-    } else {
-      // Set success information
-      resultObj.Set("success", Napi::Boolean::New(env, true));
-      resultObj.Set("error", env.Null());
-
-      // Convert processes array
-      Napi::Array processesArray = Napi::Array::New(env);
-      for (size_t i = 0; i < result.processes.size(); i++) {
-        processesArray.Set(i, Napi::String::New(env, result.processes[i]));
-      }
-      resultObj.Set("processes", processesArray);
+    Napi::Array result = Napi::Array::New(env);
+    for (size_t i = 0; i < processes.size(); i++) {
+      result.Set(i, Napi::String::New(env, processes[i]));
     }
 
-    return resultObj;
+    return result;
   } catch (const std::exception& e) {
     Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
     return env.Null();
@@ -77,9 +60,9 @@ Napi::Value GetProcessesAccessingMicrophoneWithResult(const Napi::CallbackInfo& 
 // Initialize the module exports
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "getRunningInputAudioProcesses"),
-              Napi::Function::New(env, GetRunningInputAudioProcesses));
+              Napi::Function::New(env, &GetRunningInputAudioProcesses));
   exports.Set(Napi::String::New(env, "getProcessesAccessingMicrophoneWithResult"),
-              Napi::Function::New(env, GetProcessesAccessingMicrophoneWithResult));
+              Napi::Function::New(env, &GetProcessesAccessingMicrophoneWithResult));
 
   return exports;
 }

--- a/windows/win_utils.cpp
+++ b/windows/win_utils.cpp
@@ -8,22 +8,31 @@ Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
 
   try {
     AudioProcessResult result = GetAudioInputProcesses();
-
+    
+    // Create a JavaScript object to represent the AudioProcessResult
+    Napi::Object resultObj = Napi::Object::New(env);
+    
     if (!result.success) {
-      // Create a detailed error object
-      Napi::Error error = Napi::Error::New(env, result.errorMessage);
-      error.Set("code", Napi::Number::New(env, result.errorCode));
-      error.Set("domain", Napi::String::New(env, "AudioProcessMonitor"));
-      error.ThrowAsJavaScriptException();
-      return env.Null();
+      // Set error information
+      resultObj.Set("success", Napi::Boolean::New(env, false));
+      resultObj.Set("error", Napi::String::New(env, result.errorMessage));
+      resultObj.Set("code", Napi::Number::New(env, result.errorCode));
+      resultObj.Set("domain", Napi::String::New(env, "AudioProcessMonitor"));
+      resultObj.Set("processes", Napi::Array::New(env));
+    } else {
+      // Set success information
+      resultObj.Set("success", Napi::Boolean::New(env, true));
+      resultObj.Set("error", env.Null());
+      
+      // Convert processes array
+      Napi::Array processesArray = Napi::Array::New(env);
+      for (size_t i = 0; i < result.processes.size(); i++) {
+        processesArray.Set(i, Napi::String::New(env, result.processes[i]));
+      }
+      resultObj.Set("processes", processesArray);
     }
 
-    Napi::Array resultArray = Napi::Array::New(env);
-    for (size_t i = 0; i < result.processes.size(); i++) {
-      resultArray.Set(i, Napi::String::New(env, result.processes[i]));
-    }
-
-    return resultArray;
+    return resultObj;
   } catch (const std::exception& e) {
     Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
     return env.Null();

--- a/windows/win_utils.cpp
+++ b/windows/win_utils.cpp
@@ -8,10 +8,9 @@ Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
 
   try {
     AudioProcessResult result = GetAudioInputProcesses();
-    
+
     // Create a JavaScript object to represent the AudioProcessResult
     Napi::Object resultObj = Napi::Object::New(env);
-    
     if (!result.success) {
       // Set error information
       resultObj.Set("success", Napi::Boolean::New(env, false));
@@ -23,7 +22,43 @@ Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
       // Set success information
       resultObj.Set("success", Napi::Boolean::New(env, true));
       resultObj.Set("error", env.Null());
-      
+
+      // Convert processes array
+      Napi::Array processesArray = Napi::Array::New(env);
+      for (size_t i = 0; i < result.processes.size(); i++) {
+        processesArray.Set(i, Napi::String::New(env, result.processes[i]));
+      }
+      resultObj.Set("processes", processesArray);
+    }
+
+    return resultObj;
+  } catch (const std::exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+}
+
+// Gets processes accessing microphone with structured result
+Napi::Value GetProcessesAccessingMicrophoneWithResult(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  try {
+    AudioProcessResult result = GetProcessesAccessingMicrophoneWithResult();
+
+    // Create a JavaScript object to represent the AudioProcessResult
+    Napi::Object resultObj = Napi::Object::New(env);
+    if (!result.success) {
+      // Set error information
+      resultObj.Set("success", Napi::Boolean::New(env, false));
+      resultObj.Set("error", Napi::String::New(env, result.errorMessage));
+      resultObj.Set("code", Napi::Number::New(env, result.errorCode));
+      resultObj.Set("domain", Napi::String::New(env, "AudioProcessMonitor"));
+      resultObj.Set("processes", Napi::Array::New(env));
+    } else {
+      // Set success information
+      resultObj.Set("success", Napi::Boolean::New(env, true));
+      resultObj.Set("error", env.Null());
+
       // Convert processes array
       Napi::Array processesArray = Napi::Array::New(env);
       for (size_t i = 0; i < result.processes.size(); i++) {
@@ -43,6 +78,8 @@ Napi::Value GetRunningInputAudioProcesses(const Napi::CallbackInfo& info) {
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "getRunningInputAudioProcesses"),
               Napi::Function::New(env, GetRunningInputAudioProcesses));
+  exports.Set(Napi::String::New(env, "getProcessesAccessingMicrophoneWithResult"),
+              Napi::Function::New(env, GetProcessesAccessingMicrophoneWithResult));
 
   return exports;
 }

--- a/windows/win_utils.cpp
+++ b/windows/win_utils.cpp
@@ -61,7 +61,7 @@ Napi::Value GetProcessesAccessingMicrophoneWithResult(const Napi::CallbackInfo& 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   Napi::Value (*originalAudioProcessesFunc)(const Napi::CallbackInfo&) = GetRunningInputAudioProcesses;
   Napi::Value (*microphoneAccessFunc)(const Napi::CallbackInfo&) = GetProcessesAccessingMicrophoneWithResult;
-  
+
   exports.Set("getRunningInputAudioProcesses",
               Napi::Function::New(env, originalAudioProcessesFunc));
   exports.Set("getProcessesAccessingMicrophoneWithResult",


### PR DESCRIPTION
This adds more informed error handling to the microphones access functionality. This is added because Windows users are reporting premature exiting of meeting notes functionality.

Pre-existing
`getRunningInputAudioProcesses`

And a new
`getProcessesAccessingMicrophoneWithResult`

The main difference is a new `AudioProcessResult` type. Some benefits
- Will show error states if something doesn't go as expected.
- Returns an error message if valid

Also added another check in Windows handling before existing. In addition to reading the current peak level, we add a new check for GetCurrentPadding.
